### PR TITLE
Implement pip-installable MIBs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,9 @@
 include *.txt *.md
 recursive-include docs/source *.rst *.conf *.svg *.ico *.py
 recursive-include docs Makefile
-recursive-include examples *.conf *.py
+recursive-include examples *.conf *.cfg *.in *.py *.txt *.md *.rst
 recursive-include plugins *.py
 prune docs/build
+prune examples/conf/packaged-mibs/snmpresponder-mibs-examples/snmpresponder_mibs_examples.egg-info
+prune examples/conf/packaged-mibs/snmpresponder-mibs-examples/dist
+prune examples/conf/packaged-mibs/snmpresponder-mibs-examples/build

--- a/README.md
+++ b/README.md
@@ -24,10 +24,8 @@ Features
 * SNMPv1/v2c/v3 operations with built-in protocol and transport translation capabilities
 * SNMPv3 USM supports MD5/SHA/SHA224/SHA256/SHA384/SHA512 auth and
   DES/3DES/AES128/AES192/AES256 privacy crypto algorithms
-* Supports all SNMP commands
 * Maintains multiple independent SNMP engines, network transports and MIB trees
-* Offers versatile SNMP PDU routing towards a MIB tree implementation
-* Supports asynchronous MIB objects API
+* Discovers `pip`-installable MIB implementations
 * Extension modules supporting SNMP PDU filtering and on-the-fly modification
 * Works on Linux, Windows and OS X
 

--- a/docs/source/configuration/examples/packaged-mibs.rst
+++ b/docs/source/configuration/examples/packaged-mibs.rst
@@ -1,0 +1,52 @@
+
+Packaged MIBs
+=============
+
+SNMP command responder discovers `pip <https://en.wikipedia.org/wiki/Pip_(package_manager)>`_-installed
+packages extending the *snmpresponder.mibs*
+`entry point <https://packaging.python.org/specifications/entry-points/>`_.
+
+The main advantage of packaged MIBs is easier distribution. That might make more sense for
+generally useful and reusable MIB implementations such as
+`HOST-RESOURCES-MIB <http://mibs.snmplabs.com/asn1/HOST-RESOURCES-MIB>`_.
+
+This example configuration includes
+`example Python package <https://github.com/etingof/snmpresponder/tree/master/examples/conf/packaged-mibs/snmpresponder-mibs-examples>`_,
+which could be used as a blueprint for packaging other MIB implementations.
+
+You could test this configuration by running the following command (you may need to have
+`COFFEE-POT-MIB <http://mibs.snmplabs.com/asn1/COFFEE-POT-MIB>`_ installed
+locally):
+
+.. code-block:: bash
+
+    $ snmpget -v2c -c public 127.0.0.1:1161 COFFEE-POT-MIB::potName.0
+
+.. toctree::
+   :maxdepth: 2
+
+SNMP Command Responder is configured to:
+
+* listen on UDP socket at localhost
+* form a MIB tree out of all objects imported from the *examples* extension point
+  (provided by installed *snmpresponder-mibs-examples* package)
+* respond to SNMPv2c queries
+* serve all queries against the configured MIB tree
+
+.. literalinclude:: /../../examples/conf/packaged-mibs/snmpresponderd.conf
+
+:download:`Download </../../examples/conf/packaged-mibs/snmpresponderd.conf>` configuration file.
+
+The only implemented, read-only managed object is
+`COFFEE-POT-MIB::potName.0 <http://mibs.snmplabs.com/asn1/COFFEE-POT-MIB>`_:
+
+* serves a static value for *COFFEE-POT-MIB::potName.0* object
+* only SNMP read operations are implemented
+* write operation are allowed, but has no effect
+
+.. literalinclude:: /../../examples/conf/packaged-mibs/snmpresponder-mibs-examples/snmpresponder_mibs_examples/COFFEE-POT-MIB::potName.py
+
+:download:`Download </../../examples/conf/packaged-mibs/snmpresponder-mibs-examples/snmpresponder_mibs_examples/COFFEE-POT-MIB::potName.py>` MIB implementation.
+
+For more information on MIB implementation refer to the
+`MIB implementation <mib-implementation-chapter>`_ chapter in the documentation.

--- a/docs/source/configuration/snmpresponderd.rst
+++ b/docs/source/configuration/snmpresponderd.rst
@@ -439,6 +439,44 @@ Responder should search for MIB modules expressed in pysnmp MIB/SMI data model.
 The matching modules will be loaded, executed and brought on-line by SNMP
 Command Responder and served to SNMP managers.
 
+.. code-block:: bash
+
+    managed-objects-group {
+      mib-text-search-path-list: http://mibs.snmplabs.com/asn1/
+      mib-code-modules-pattern-list: ${config-dir}/managed-objects/.*py[co]?
+
+      mib-tree-id: managed-objects-1
+    }
+
+.. note::
+
+   Refer to `MIB implementation <mib-implementation-chapter>`_ chapter for
+   information on how to prepare MIB implementation module.
+
+.. _mib-code-packages-pattern-list:
+
+*mib-code-packages-pattern-list*
+++++++++++++++++++++++++++++++++
+
+List of regular expressions matching the files residing in the Python package
+extending the *snmpresponder.mibs*
+`entry point <https://packaging.python.org/specifications/entry-points/>`_.
+
+SNMP Command Responder will discover such packages, import the extensions they
+announce and walk through the files it finds under the top-level package
+directory. Matching files will be treated as MIB modules expressed in pysnmp
+MIB/SMI data model i.e. loaded, executed and brought on-line by SNMP
+Command Responder and served to SNMP managers.
+
+.. code-block:: bash
+
+    managed-objects-group {
+      mib-text-search-path-list: http://mibs.snmplabs.com/asn1/
+      mib-code-packages-pattern-list: examples\..*
+
+      mib-tree-id: managed-objects-1
+    }
+
 .. note::
 
    Refer to `MIB implementation <mib-implementation-chapter>`_ chapter for

--- a/docs/source/mib-implementation/index.rst
+++ b/docs/source/mib-implementation/index.rst
@@ -228,6 +228,34 @@ this:
       mib-tree-id: managed-objects-1
     }
 
+Alternatively, you could put your *SNMPv2-MIB::sysName.py* implementation file into a
+`Python package <https://github.com/etingof/snmpresponder/tree/master/examples/conf/packaged-mibs/snmpresponder-mibs-examples>`_,
+then register the directory containing these MIB files via the entry point
+*snmpresponder.mibs*:
+
+.. code-block:: python
+
+   'entry_points': {
+     'snmpresponder.mibs': 'examples = mypackage'
+   },
+
+With the above registration, SNMP command responder will import *mypackage*
+and consider importing modules matching `mib-code-packages-pattern-list`
+regexp:
+
+.. code-block:: bash
+
+    snmpv2-mib-objects {
+      mib-text-search-path-list: http://mibs.snmplabs.com/asn1/
+      mib-code-packages-pattern-list: mypackage\..*
+
+      mib-tree-id: managed-objects-1
+    }
+
+The main advantage of packaging MIB implementations is that the package becomes
+`pip`-installable and easily distributable. That might be especially convenient
+for generally useful MIB implementations such as *HOST-RESOURCES-MIB*.
+
 Once you are done setting things up and restarting *snmpresponderd*, you should
 be able to read the hostname via SNMP:
 

--- a/examples/conf/packaged-mibs/snmpresponder-mibs-examples/CHANGES.txt
+++ b/examples/conf/packaged-mibs/snmpresponder-mibs-examples/CHANGES.txt
@@ -1,0 +1,5 @@
+
+Revision 0.0.0, released XX-01-2019
+-----------------------------------
+
+- Initial public release

--- a/examples/conf/packaged-mibs/snmpresponder-mibs-examples/LICENSE.txt
+++ b/examples/conf/packaged-mibs/snmpresponder-mibs-examples/LICENSE.txt
@@ -1,0 +1,24 @@
+Copyright (c) 2019, Ilya Etingof <etingof@gmail.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, 
+    this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE. 

--- a/examples/conf/packaged-mibs/snmpresponder-mibs-examples/MANIFEST.in
+++ b/examples/conf/packaged-mibs/snmpresponder-mibs-examples/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.txt *.md

--- a/examples/conf/packaged-mibs/snmpresponder-mibs-examples/README.md
+++ b/examples/conf/packaged-mibs/snmpresponder-mibs-examples/README.md
@@ -1,0 +1,57 @@
+
+Example MIB implementation
+--------------------------
+
+The [SNMP Command Responder](http://snmplabs.com/snmpresponder) tool runs one
+or more SNMP agents and maintains one or more trees of SNMP managed objects
+(i.e. MIBs). Users can interface those managed objects with the data they
+are willing to serve over SNMP.
+
+User MIBs can be handed over to SNMP Command Responder as stand-alone files
+or as `pip`-installable Python packages. In the latter case SNMP Command
+Responder will discover those MIBs and serve them (if configured to do so).
+
+The `snmpresponder-mibs-examples` Python package contains a blueprint though
+functional MIB implementation aiming at guiding the user to package their own
+MIB implementations.
+
+How to implement MIBs
+---------------------
+
+MIB implementation is not dependent on the way how Python MIB modules
+are distributed, the same MIB module can be shipped as a stand-alone
+Python file or within an installable Python package.
+
+Please, refer to SNMP Command Responder
+[documentation](http://snmplabs.com/snmpresponder/mib-implementation/index.html)
+for more information on MIB implementation workflow.
+
+How to use MIB implementation
+-----------------------------
+
+First you need to [configure](http://snmplabs.com/snmpresponder/configuration/index.html)
+SNMP Command Responder to stand up at least one SNMP agent. Proceed by
+`pip`-installing packaged MIB implementation of your choice and configuring
+the desired MIB(s) from the installed package by means of the
+[mib-code-packages-pattern-list](http://snmplabs.com/snmpresponder/configuration/snmpresponderd.html#mib-trees)
+option:
+
+```
+managed-objects-group {
+  mib-text-search-path-list: http://mibs.snmplabs.com/asn1/
+
+  # Load up and serve all MIBs from "snmpresponder-mibs-examples" package
+  mib-code-packages-pattern-list: examples\..*
+
+  mib-tree-id: managed-objects-1
+}
+```
+
+Getting help
+------------
+
+If something does not work as expected or we are missing an interesting feature,
+[open an issue](https://github.com/etingof/snmpresponder/issues) at GitHub or
+post your question [on Stack Overflow](https://stackoverflow.com/questions/ask).
+
+Copyright (c) 2019, [Ilya Etingof](mailto:etingof@gmail.com). All rights reserved.

--- a/examples/conf/packaged-mibs/snmpresponder-mibs-examples/requirements.txt
+++ b/examples/conf/packaged-mibs/snmpresponder-mibs-examples/requirements.txt
@@ -1,0 +1,1 @@
+snmpresponder

--- a/examples/conf/packaged-mibs/snmpresponder-mibs-examples/setup.cfg
+++ b/examples/conf/packaged-mibs/snmpresponder-mibs-examples/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = LICENSE.txt

--- a/examples/conf/packaged-mibs/snmpresponder-mibs-examples/setup.py
+++ b/examples/conf/packaged-mibs/snmpresponder-mibs-examples/setup.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
-"""SNMP Command Responder.
+"""SNMP Command Responder MIBs implementations extension module.
 
-The SNMP Command Responder application is designed to serve user
-data over SNMPv1/v2c/v3.
+Extension module to SNMP Command Responder tool implementing some
+example MIBs.
 """
 import sys
 import os
-import glob
 
 classifiers = """\
 Development Status :: 3 - Alpha
@@ -56,7 +55,7 @@ try:
     from setuptools import setup
 
     params = {
-        'install_requires': ['pysnmp>=5.0.0'],
+        'install_requires': ['snmpresponder<=0.1.0'],
         'zip_safe': True
     }
 
@@ -68,14 +67,15 @@ except ImportError:
 
     from distutils.core import setup
 
-    params = {}
-    params['requires'] = ['pysnmp(>=5.0.0)']
+    params = {
+        'requires': ['snmpresponder(<=0.1.0)']
+    }
 
 doclines = [x.strip() for x in (__doc__ or '').split('\n') if x]
 
 params.update(
-    {'name': "snmpresponder",
-     'version':  open(os.path.join('snmpresponder', '__init__.py')).read().split('\'')[1],
+    {'name': "snmpresponder-mibs-examples",
+     'version':  open(os.path.join('snmpresponder_mibs_examples', '__init__.py')).read().split('\'')[1],
      'description': doclines[0],
      'long_description': ' '.join(doclines[1:]),
      'maintainer': 'Ilya Etingof <etingof@gmail.com>',
@@ -84,48 +84,11 @@ params.update(
      'url': "https://github.com/etingof/snmpresponder",
      'platforms': ['any'],
      'classifiers': [x for x in classifiers.split('\n') if x],
-     'packages': ['snmpresponder', 'snmpresponder.plugins'],
+     'packages': ['snmpresponder_mibs_examples'],
      'entry_points': {
-         'console_scripts': [
-             'snmpresponderd = snmpresponder.snmpresponderd:main'
-         ]
+         'snmpresponder.mibs': 'examples = snmpresponder_mibs_examples'
      },
      'license': "BSD"}
 )
-
-
-params['data_files'] = [
-    ('snmpresponder/' + 'plugins', glob.glob(os.path.join('plugins', '*.py')))
-]
-
-if 'py2exe' in sys.argv:
-    import py2exe
-
-    # pysnmp used by snmpresponder dynamically loads some of its *.py files
-    params['options'] = {
-        'py2exe': {
-            'includes': [
-                'pysnmp.smi.mibs.*',
-                'pysnmp.smi.mibs.instances.*'
-            ],
-            'bundle_files': 1,
-            'compressed': True
-        }
-    }
-
-    params['zipfile'] = None
-
-    del params['data_files']  # no need to store these in .exe
-
-    # additional modules used by snmpresponder but not seen by py2exe
-    for m in ('random',):
-        try:
-            __import__(m)
-        except ImportError:
-            continue
-        else:
-            params['options']['py2exe']['includes'].append(m)
-
-    print("!!! Make sure your pysnmp/pyasn1 packages are NOT .egg'ed!!!")
 
 setup(**params)

--- a/examples/conf/packaged-mibs/snmpresponder-mibs-examples/snmpresponder_mibs_examples/COFFEE-POT-MIB::potName.py
+++ b/examples/conf/packaged-mibs/snmpresponder-mibs-examples/snmpresponder_mibs_examples/COFFEE-POT-MIB::potName.py
@@ -1,0 +1,93 @@
+"""SNMP MIB module (COFFEE-POT-MIB) expressed in pysnmp data model.
+
+This Python module is designed to be imported and executed by the
+pysnmp library.
+
+See http://snmplabs.com/pysnmp for further information.
+
+Notes
+-----
+ASN.1 source http://mibs.snmplabs.com:80/asn1/COFFEE-POT-MIB
+Produced by pysmi-0.4.0 at Sat Jan 12 14:01:57 2019
+On host igarlic platform Darwin version 17.7.0 by user ilya
+Using Python version 3.6.0 (v3.6.0:41df79263a11, Dec 22 2016, 17:23:13)
+"""
+if 'mibBuilder' not in globals():
+    import sys
+
+    sys.stderr.write(__doc__)
+    sys.exit(1)
+
+
+mibBuilder = globals()['mibBuilder']
+
+MibScalarInstance, = mibBuilder.importSymbols(
+    'SNMPv2-SMI',
+    'MibScalarInstance'
+)
+
+# Import Managed Objects to base Managed Objects Instances on
+
+potName, = mibBuilder.importSymbols(
+    "COFFEE-POT-MIB",
+    "potName"
+)
+
+
+# MIB Managed Objects in the order of their OIDs
+
+class PotnameObjectInstance(MibScalarInstance):
+    """Scalar Managed Object Instance with MIB instrumentation hooks.
+
+    User can override none, some or all of the method below interfacing
+    them to the data source they want to manage through SNMP.
+    Non-overridden methods could just be removed from this class.
+
+    See the SMI data model documentation at `http://snmplabs.com/pysnmp`.
+    """
+    def readTest(self, varBind, **context):
+        cbFun = context['cbFun']
+        cbFun(varBind, **context)
+
+    def readGet(self, varBind, **context):
+        name, value = varBind
+
+        cbFun = context['cbFun']
+        value = self.syntax.clone('mypot')
+        cbFun((name, value), **context)
+
+    def readTestNext(self, varBind, **context):
+        name, value = varBind
+
+        if name >= self.name:
+            MibScalarInstance.readTestNext(self, varBind, **context)
+
+        else:
+            cbFun = context['cbFun']
+            cbFun((self.name, value), **context)
+
+    def readGetNext(self, varBind, **context):
+        name, value = varBind
+
+        if name >= self.name:
+            MibScalarInstance.readGetNext(self, varBind, **context)
+
+        else:
+            value = self.syntax.clone('mypot')
+
+            cbFun = context['cbFun']
+            cbFun((self.name, value), **context)
+
+
+_potName = PotnameObjectInstance(
+     potName.name,
+     (0,),
+     potName.syntax
+)
+
+# Export Managed Objects Instances to the MIB builder
+
+mibBuilder.exportSymbols(
+    "__COFFEE-POT-MIB",
+    **{"potName": _potName}
+)

--- a/examples/conf/packaged-mibs/snmpresponder-mibs-examples/snmpresponder_mibs_examples/__init__.py
+++ b/examples/conf/packaged-mibs/snmpresponder-mibs-examples/snmpresponder_mibs_examples/__init__.py
@@ -1,0 +1,8 @@
+#
+# This file is part of snmpresponder software.
+#
+# Copyright (c) 2019, Ilya Etingof <etingof@gmail.com>
+# License: http://snmplabs.com/snmpresponder/license.html
+#
+# http://www.python.org/dev/peps/pep-0396/
+__version__ = '0.0.0'

--- a/examples/conf/packaged-mibs/snmpresponderd.conf
+++ b/examples/conf/packaged-mibs/snmpresponderd.conf
@@ -1,0 +1,61 @@
+#
+# SNMP Command Responder configuration file
+#
+
+config-version: 1
+program-name: snmpresponder
+
+snmp-credentials-group {
+  snmp-transport-domain: 1.3.6.1.6.1.1.100
+  snmp-bind-address: 127.0.0.1:1161
+
+  snmp-engine-id: 0x0102030405070809
+
+  snmp-community-name: public
+  snmp-security-name: public
+  snmp-security-model: 2
+  snmp-security-level: 1
+
+  snmp-credentials-id: snmp-credentials
+}
+
+context-group {
+  snmp-context-engine-id-pattern: .*?
+  snmp-context-name-pattern: .*?
+
+  snmp-context-id: any-context
+}
+
+content-group {
+  snmp-pdu-type-pattern: .*?
+  snmp-pdu-oid-prefix-pattern-list: .*?
+
+  snmp-content-id: any-content
+}
+
+peers-group {
+  snmp-transport-domain: 1.3.6.1.6.1.1.100
+  snmp-bind-address-pattern-list: .*?
+  snmp-peer-address-pattern-list: .*?
+
+  snmp-peer-id: 100
+}
+
+managed-objects-group {
+  mib-text-search-path-list: http://mibs.snmplabs.com/asn1/
+
+  # List of Python packages to import in the MIB builder context
+  mib-code-packages-pattern-list: examples\..*
+
+  mib-tree-id: managed-objects-1
+}
+
+routing-map {
+  matching-snmp-context-id-list: any-context
+  matching-snmp-content-id-list: any-content
+
+  matching-snmp-credentials-id-list: snmp-credentials
+  matching-snmp-peer-id-list: 100
+
+  using-mib-tree-id: managed-objects-1
+}


### PR DESCRIPTION
Introduce the feature of packing MIB implementations into
pip-installable and discoverable packages for SNMP Command Responder
to load and serve.

This patch also adds some documentation and example blueprint
package containing a trivial MIB implementation.